### PR TITLE
Add front end progress page

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,6 +4,7 @@ import { CSSReset, ThemeProvider } from '@chakra-ui/core';
 
 import LandingPage from './routes/LandingPage';
 import LoginRegister from './components/auth/LoginRegister';
+import Progress from './routes/Progress';
 import MealLog from './routes/MealLog';
 import EnterIngredients from './routes/EnterIngredients';
 import AccountSettings from './routes/AccountSettings';
@@ -23,6 +24,9 @@ function App() {
 					</Route>
 					<Route exact path="/auth">
 						<LoginRegister />
+					</Route>
+					<Route exact path="/progress">
+						<Progress></Progress>
 					</Route>
 					<Route exact path="/MealLog">
 						<MealLog></MealLog>

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -10,3 +10,17 @@ export const register = (username, password, calorieGoal) => {
 		},
 	});
 };
+
+export const getProgress = username => {
+	// Hardcoded since backend endpoint doesn't exist yet
+	return new Promise(resolve => resolve(0.42));
+
+	// TODO: update this to the proper endpoint once created
+	return fetch(`/progress/${username}`, {
+		method: 'GET',
+		headers: {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+		},
+	});
+};

--- a/client/src/routes/AccountSettings.js
+++ b/client/src/routes/AccountSettings.js
@@ -1,10 +1,17 @@
 import React from 'react';
-import { Flex, Heading, FormControl,
-  FormLabel,
-  FormErrorMessage,
-  FormHelperText,
-  Input, Box, Button,Text } from '@chakra-ui/core';
-import { Avatar, AvatarBadge, Stack } from "@chakra-ui/core";
+import {
+	Flex,
+	Heading,
+	FormControl,
+	FormLabel,
+	FormErrorMessage,
+	FormHelperText,
+	Input,
+	Box,
+	Button,
+	Text,
+} from '@chakra-ui/core';
+import { Avatar, AvatarBadge, Stack } from '@chakra-ui/core';
 
 import LoggedInNavbar from '../components/LoggedInNavbar';
 
@@ -12,44 +19,39 @@ function MealLog() {
 	return (
 		<Flex width="100%" height="100vh" direction="column">
 			<LoggedInNavbar></LoggedInNavbar>
-			<br></br>
-			<Heading>Account Settings</Heading>
-			<Heading as="h3" size="l">
-  			</Heading>
-  			<br></br>
-  			<FormControl>
-			  <FormLabel htmlFor="profilePicture">Profile Picture</FormLabel>
-			</FormControl>
-			<br></br>
-			<Stack isInline>
-  				<Avatar
-   				 size="2xl"
-   				 src="https://bit.ly/broken-link"
-  				/>
-  			</Stack>
-  			<br></br>
-			<Button
-							background="white"
-							variantColor="teal"
-							variant="outline"
-							size="md"
-							width="300px"
-						>
-						Delete Account
+			<Flex direction="column" m="3rem">
+				<Heading>Account Settings</Heading>
+				<Heading as="h3" size="l"></Heading>
+				<br></br>
+				<FormControl>
+					<FormLabel htmlFor="profilePicture">Profile Picture</FormLabel>
+				</FormControl>
+				<br></br>
+				<Stack isInline>
+					<Avatar size="2xl" src="https://bit.ly/broken-link" />
+				</Stack>
+				<br></br>
+				<Button
+					background="white"
+					variantColor="teal"
+					variant="outline"
+					size="md"
+					width="300px"
+				>
+					Delete Account
+				</Button>
+				<br></br>
 
-						</Button>
-			<br></br>
-				
-			<Button
-							background="white"
-							variantColor="teal"
-							variant="outline"
-							size="md"
-							width="300px"
-						>
-						Change Password
-
-						</Button>
+				<Button
+					background="white"
+					variantColor="teal"
+					variant="outline"
+					size="md"
+					width="300px"
+				>
+					Change Password
+				</Button>
+			</Flex>
 		</Flex>
 	);
 }

--- a/client/src/routes/DietInformation.js
+++ b/client/src/routes/DietInformation.js
@@ -1,10 +1,17 @@
 import React from 'react';
-import { Flex, Heading, FormControl,
-  FormLabel,
-  FormErrorMessage,
-  FormHelperText,
-  Input, Box, Button,Text } from '@chakra-ui/core';
-import { Avatar, AvatarBadge, Stack } from "@chakra-ui/core";
+import {
+	Flex,
+	Heading,
+	FormControl,
+	FormLabel,
+	FormErrorMessage,
+	FormHelperText,
+	Input,
+	Box,
+	Button,
+	Text,
+} from '@chakra-ui/core';
+import { Avatar, AvatarBadge, Stack } from '@chakra-ui/core';
 
 import LoggedInNavbar from '../components/LoggedInNavbar';
 
@@ -12,58 +19,74 @@ function MealLog() {
 	return (
 		<Flex width="100%" height="100vh" direction="column">
 			<LoggedInNavbar></LoggedInNavbar>
-			<br></br>
-			<Heading>Diet Information</Heading>
-			<Heading as="h3" size="l">
-  			</Heading>
-  			<br></br>
-			<Stack>
-				<FormControl>
-				  <FormLabel htmlFor="dietRestrictions">Diet Restrictions:</FormLabel>
-				  <Input id="dietRestrictions" placeholder="Eg. vegetarian, vegan, keto, etc. " width="500px" />
-				</FormControl>
+			<Flex direction="column" m="3rem">
+				<Heading>Diet Information</Heading>
+				<Heading as="h3" size="l"></Heading>
 				<br></br>
-				<FormControl>
-				  <FormLabel htmlFor="Diet Length">Diet Length:</FormLabel>
-				  <Input id="dietRestrictions" placeholder="Eg. one week, one month, etc." width="500px" />
-				</FormControl>
+				<Stack>
+					<FormControl>
+						<FormLabel htmlFor="dietRestrictions">Diet Restrictions:</FormLabel>
+						<Input
+							id="dietRestrictions"
+							placeholder="Eg. vegetarian, vegan, keto, etc. "
+							width="500px"
+						/>
+					</FormControl>
+					<br></br>
+					<FormControl>
+						<FormLabel htmlFor="Diet Length">Diet Length:</FormLabel>
+						<Input
+							id="dietRestrictions"
+							placeholder="Eg. one week, one month, etc."
+							width="500px"
+						/>
+					</FormControl>
+					<br></br>
+					<FormControl>
+						<FormLabel htmlFor="Diet Goals">Diet Goals:</FormLabel>
+						<Input
+							id="dietGoals"
+							placeholder="Eg. eat healthy, lose weight, etc. "
+							width="500px"
+						/>
+					</FormControl>
+					<br></br>
+					<FormControl>
+						<FormLabel htmlFor="Daily Calorie Intake">
+							Daily Calorie Intake:
+						</FormLabel>
+						<Input
+							id="dailyCalorieIntake"
+							placeholder="1000 calories, etc. "
+							width="500px"
+						/>
+					</FormControl>
+				</Stack>
 				<br></br>
-				<FormControl>
-				  <FormLabel htmlFor="Diet Goals">Diet Goals:</FormLabel>
-				  <Input id="dietGoals" placeholder="Eg. eat healthy, lose weight, etc. " width="500px"/>
-				</FormControl>
 				<br></br>
-				<FormControl>
-				  <FormLabel htmlFor="Daily Calorie Intake">Daily Calorie Intake:</FormLabel>
-				  <Input id="dailyCalorieIntake" placeholder="1000 calories, etc. " width="500px"/>
-				</FormControl>
-			</Stack>
-			<br></br>
-  			<br></br>
-  			<Stack shouldWrapChildren isInline spacing={30}>
-				<Button
-								background="white"
-								variantColor="teal"
-								variant="outline"
-								size="md"
-								width="300px"
-							>
-							Cancel
+				<Stack shouldWrapChildren isInline spacing={30}>
+					<Button
+						background="white"
+						variantColor="teal"
+						variant="outline"
+						size="md"
+						width="300px"
+					>
+						Cancel
+					</Button>
+					<br></br>
 
-				</Button>
-				<br></br>
-					
-				<Button
-								background="white"
-								variantColor="teal"
-								variant="outline"
-								size="md"
-								width="300px"
-							>
-							Save
-
-				</Button>
-			</Stack>
+					<Button
+						background="white"
+						variantColor="teal"
+						variant="outline"
+						size="md"
+						width="300px"
+					>
+						Save
+					</Button>
+				</Stack>
+			</Flex>
 		</Flex>
 	);
 }

--- a/client/src/routes/EnterIngredients.js
+++ b/client/src/routes/EnterIngredients.js
@@ -1,13 +1,22 @@
 import React from 'react';
-import { Flex, Heading,  FormControl, Stack,
-  FormLabel,
-  FormErrorMessage,
-  FormHelperText,
-  Input, Box, Button,Text, NumberInput,
-  NumberInputField,
-  NumberInputStepper,
-  NumberIncrementStepper,
-  NumberDecrementStepper, } from '@chakra-ui/core';
+import {
+	Flex,
+	Heading,
+	FormControl,
+	Stack,
+	FormLabel,
+	FormErrorMessage,
+	FormHelperText,
+	Input,
+	Box,
+	Button,
+	Text,
+	NumberInput,
+	NumberInputField,
+	NumberInputStepper,
+	NumberIncrementStepper,
+	NumberDecrementStepper,
+} from '@chakra-ui/core';
 
 import LoggedInNavbar from '../components/LoggedInNavbar';
 
@@ -15,53 +24,53 @@ function EnterIngredients() {
 	return (
 		<Flex width="100%" height="100vh" direction="column">
 			<LoggedInNavbar></LoggedInNavbar>
-			<br></br>
-			<Heading>Input Ingredients</Heading>
-			<br></br>
-			<Heading as="h2" size="l">
-			    Current Ingredients
-			</Heading>
-			<Heading as="h3" size="l">
-   			 ##NEED BACKEND TO LIST CURRENT INGREDIENTS##
-  			</Heading>
-  			<br></br>
-			<Stack shouldWrapChildren isInline spacing={30}>
-				<FormControl>
-				  <FormLabel htmlFor="ingredients">Ingredient:</FormLabel>
-				  <Input id="ingredients" placeholder="Ingredient" />
-				</FormControl>
-				<FormControl>
-				  <FormLabel htmlFor="ingredients">Quantity</FormLabel>
-					<NumberInput>
-					  <NumberInputField />
-					  <NumberInputStepper>
-					    <NumberIncrementStepper />
-					    <NumberDecrementStepper />
-					  </NumberInputStepper>
-					</NumberInput>
-				</FormControl>				
-			</Stack>
-			<br></br>
-			<Button
-							background="white"
-							variantColor="teal"
-							variant="outline"
-							size="md"
-							width="200px"
-						>
-							Add ingredient
-			</Button>
-			<br></br>
-			<Button
-							background="white"
-							variantColor="teal"
-							variant="outline"
-							size="md"
-							width="300px"
-							
-						>
-							Search Recipes Using These Ingredients
-			</Button>
+			<Flex direction="column" m="3rem">
+				<Heading>Input Ingredients</Heading>
+				<br></br>
+				<Heading as="h2" size="l">
+					Current Ingredients
+				</Heading>
+				<Heading as="h3" size="l">
+					##NEED BACKEND TO LIST CURRENT INGREDIENTS##
+				</Heading>
+				<br></br>
+				<Stack shouldWrapChildren isInline spacing={30}>
+					<FormControl>
+						<FormLabel htmlFor="ingredients">Ingredient:</FormLabel>
+						<Input id="ingredients" placeholder="Ingredient" />
+					</FormControl>
+					<FormControl>
+						<FormLabel htmlFor="ingredients">Quantity</FormLabel>
+						<NumberInput>
+							<NumberInputField />
+							<NumberInputStepper>
+								<NumberIncrementStepper />
+								<NumberDecrementStepper />
+							</NumberInputStepper>
+						</NumberInput>
+					</FormControl>
+				</Stack>
+				<br></br>
+				<Button
+					background="white"
+					variantColor="teal"
+					variant="outline"
+					size="md"
+					width="200px"
+				>
+					Add ingredient
+				</Button>
+				<br></br>
+				<Button
+					background="white"
+					variantColor="teal"
+					variant="outline"
+					size="md"
+					width="300px"
+				>
+					Search Recipes Using These Ingredients
+				</Button>
+			</Flex>
 		</Flex>
 	);
 }

--- a/client/src/routes/MealLog.js
+++ b/client/src/routes/MealLog.js
@@ -1,9 +1,16 @@
 import React from 'react';
-import { Flex, Heading, FormControl,
-  FormLabel,
-  FormErrorMessage,
-  FormHelperText,
-  Input, Box, Button,Text } from '@chakra-ui/core';
+import {
+	Flex,
+	Heading,
+	FormControl,
+	FormLabel,
+	FormErrorMessage,
+	FormHelperText,
+	Input,
+	Box,
+	Button,
+	Text,
+} from '@chakra-ui/core';
 
 import LoggedInNavbar from '../components/LoggedInNavbar';
 
@@ -11,29 +18,30 @@ function MealLog() {
 	return (
 		<Flex width="100%" height="100vh" direction="column">
 			<LoggedInNavbar></LoggedInNavbar>
-			<br></br>
-			<Heading>Meal Log</Heading>
-			<Heading as="h3" size="l">
-   			 ##NEED BACKEND TO LIST MEALS##
-  			</Heading>
-  			<br></br>
-  			<Heading>Add a Meal</Heading>
-  			<FormControl>
-			  <FormLabel htmlFor="mealName">Meal Name</FormLabel>
-			  <Input id="mealName" placeholder="Meal Name" />
-			  <FormLabel htmlFor="quantity">Quantity</FormLabel>
-			  <Input id="quantity" placeholder="Quantity" />
-			</FormControl>
-			<br></br>
-			<Button
-							background="white"
-							variantColor="teal"
-							variant="outline"
-							size="md"
-							width = "300px"
-						>
-							Add a Meal
-						</Button>
+			<Flex direction="column" m="3rem">
+				<Heading>Meal Log</Heading>
+				<Heading as="h3" size="l">
+					##NEED BACKEND TO LIST MEALS##
+				</Heading>
+				<br></br>
+				<Heading>Add a Meal</Heading>
+				<FormControl>
+					<FormLabel htmlFor="mealName">Meal Name</FormLabel>
+					<Input id="mealName" placeholder="Meal Name" />
+					<FormLabel htmlFor="quantity">Quantity</FormLabel>
+					<Input id="quantity" placeholder="Quantity" />
+				</FormControl>
+				<br></br>
+				<Button
+					background="white"
+					variantColor="teal"
+					variant="outline"
+					size="md"
+					width="300px"
+				>
+					Add a Meal
+				</Button>
+			</Flex>
 		</Flex>
 	);
 }

--- a/client/src/routes/Progress.js
+++ b/client/src/routes/Progress.js
@@ -1,0 +1,49 @@
+import React, { useEffect, useState } from 'react';
+import {
+	Flex,
+	Heading,
+	CircularProgress,
+	CircularProgressLabel,
+	Text,
+} from '@chakra-ui/core';
+
+import { getProgress } from '../api';
+import LoggedInNavbar from '../components/LoggedInNavbar';
+
+function MealLog() {
+	// TODO: pull username from
+	const username = 'max@maxmusing.com';
+	const [progress, setProgress] = useState(null);
+
+	useEffect(() => {
+		if (!username) {
+			return;
+		}
+
+		getProgress(username).then(fetchedProgress => setProgress(fetchedProgress));
+	}, [username]);
+
+	return (
+		<Flex width="100%" direction="column">
+			<LoggedInNavbar></LoggedInNavbar>
+			<Flex direction="column" m="3rem">
+				<Heading mb="2rem">Progress</Heading>
+				{progress && (
+					<>
+						<Text mb="2rem" fontSize="2xl">
+							You've consumed {Math.round(progress * 100)}% of your daily
+							calorie goal for the day.
+						</Text>
+						<CircularProgress value={progress * 100} size="20rem" capIsRound>
+							<CircularProgressLabel>
+								{Math.round(progress * 100)}%
+							</CircularProgressLabel>
+						</CircularProgress>
+					</>
+				)}
+			</Flex>
+		</Flex>
+	);
+}
+
+export default MealLog;


### PR DESCRIPTION
Adds the progress page to the front end to show what percent of the user's daily calorie goal has been met.

<img width="1007" alt="Screen Shot 2020-02-23 at 16 43 50" src="https://user-images.githubusercontent.com/15393239/75120727-b4968f00-565b-11ea-8bb6-0715fe679a4c.png">

The data is currently hard-coded since it looks like there isn't a backend endpoint for progress yet (looks like just a method, correct me if I'm wrong @leakkari). The front end is set up to pull from a `GET` endpoint at `/progress/{username}`.